### PR TITLE
gang / 230325 / 1문제

### DIFF
--- a/BOJ/boj10830.py
+++ b/BOJ/boj10830.py
@@ -1,0 +1,37 @@
+import sys
+input = sys.stdin.readline
+
+def multiply(m1, m2):
+  result = [[0] * n for _ in range(n)]
+
+  for i in range(n):
+    for j in range(n):
+      r = 0
+      for h in range(n):
+        r += m1[i][h] * m2[h][j]
+      result[i][j] = r % 1000
+
+  return result
+
+def f(m, s):
+  if s == 1:
+    return m
+  
+  mtx = f(m, s // 2)
+  if s % 2 == 0:
+    return multiply(mtx, mtx)
+  else:
+    return multiply(multiply(mtx, mtx), m)
+  
+
+n, b = map(int, input().split())
+
+matrix = []
+for _ in range(n):
+  matrix.append(list(map(int, input().split())))
+
+result = f(matrix, b)
+for i in range(n):
+  for j in range(n):
+    print(result[i][j] % 1000, end=' ')
+  print()


### PR DESCRIPTION
처음 이 문제를 보고 dp로 풀 수 있겠다고 생각했는데, dp로 풀기엔 메모리가 너무 많이 필요하고 결국 한번씩 행렬을 곱해가면서 값을 저장해야하기 때문에 안될 것이라고 판단했습니다.
그래서 재귀로 B를 절반씩 감소시키면서 문제를 풀었습니다. 이때 f(m, s // 2)이 식이 4번 반복되는 것이 시간초과의 원인이 되어 이 식을 미리 변수에 할당하여 해결했습니다.